### PR TITLE
feat: Support for GNOME 45

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -30,16 +30,17 @@ import Shell from 'gi://Shell';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 
+
 // Attention: This module is not available as an ECMAScript Module
 const ByteArray = imports.byteArray;
 
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 import * as Settings from './settings.js';
+
 import * as Util from 'resource:///org/gnome/shell/misc/util.js';
 
-import * as Shell from 'gi://Shell';
 
-import { Extension, gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
+import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
 
 const netSpeedUnits = ['B/s', 'K/s', 'M/s', 'G/s', 'T/s', 'P/s', 'E/s', 'Z/s', 'Y/s'];
 
@@ -380,7 +381,7 @@ export default class SSMExtension extends Extension {
         lastCPUUsed = 0;
         lastCPUTotal = 0;
 
-        this._prefs = new Settings.Prefs();
+        this._prefs = new Settings.Prefs(this.getSettings(Settings.SETTING_SCHEMA));
 
         this._texts = {
             cpuUsageText: this._prefs.CPU_USAGE_TEXT.get(),

--- a/src/extension.js
+++ b/src/extension.js
@@ -20,22 +20,25 @@
 
 /* exported init */
 
-const { GObject, St, Clutter, GLib, Gio } = imports.gi;
+import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
+import St from 'gi://St';
+import Clutter from 'gi://Clutter';
+import Gio from 'gi://Gio';
 
-const Main = imports.ui.main;
-const PanelMenu = imports.ui.panelMenu;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+
+// Attention: This module is not available as an ECMAScript Module
 const ByteArray = imports.byteArray;
-const PopupMenu = imports.ui.popupMenu;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Settings = Me.imports.settings;
-const Util = imports.misc.util;
-const Gettext = imports.gettext;
-const GettextDomain = Me.metadata['gettext-domain'];
-const Domain = Gettext.domain(GettextDomain);
-const Shell = imports.gi.Shell;
 
-const _ = Domain.gettext;
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+import * as Settings from './settings.js';
+import * as Util from 'resource:///org/gnome/shell/misc/util.js';
+
+import * as Shell from 'gi://Shell';
+
+import { Extension, gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 const netSpeedUnits = ['B/s', 'K/s', 'M/s', 'G/s', 'T/s', 'P/s', 'E/s', 'Z/s', 'Y/s'];
 
@@ -317,6 +320,11 @@ const toDisplayString = (
 
 const Indicator = GObject.registerClass(
     class Indicator extends PanelMenu.Button {
+        constructor() {
+            super();
+            this.extension = Extension.lookupByUUID('ssm-gnome@lgiki.net');
+        }
+
         _init() {
             super._init(0.0, 'Simple System Monitor');
 
@@ -342,10 +350,10 @@ const Indicator = GObject.registerClass(
 
             const settingMenuItem = new PopupMenu.PopupMenuItem(_('Setting'));
             settingMenuItem.connect('activate', () => {
-                if (typeof ExtensionUtils.openPrefs === 'function') {
-                    ExtensionUtils.openPrefs();
+                if (typeof this.extension.openPreferences === 'function') {
+                    this.extension.openPreferences();
                 } else {
-                    Util.spawn(['gnome-shell-extension-prefs', Me.uuid]);
+                    Util.spawn(['gnome-shell-extension-prefs', extension.uuid]);
                 }
             });
             this.menu.addMenuItem(settingMenuItem);
@@ -363,11 +371,7 @@ const Indicator = GObject.registerClass(
     },
 );
 
-class Extension {
-    constructor(uuid) {
-        this._uuid = uuid;
-    }
-
+export default class SSMExtension extends Extension {
     enable() {
         lastTotalNetDownBytes = 0;
         lastTotalNetUpBytes = 0;
@@ -407,7 +411,7 @@ class Extension {
         const extensionPosition = this._prefs.EXTENSION_POSITION.get();
         const extensionOrder = this._prefs.EXTENSION_ORDER.get();
 
-        Main.panel.addToStatusArea(this._uuid, this._indicator, extensionOrder, extensionPosition);
+        Main.panel.addToStatusArea(this.uuid, this._indicator, extensionOrder, extensionPosition);
 
         this._timeout = GLib.timeout_add_seconds(
             GLib.PRIORITY_DEFAULT_IDLE,
@@ -562,9 +566,4 @@ class Extension {
         this._prefs.IS_SWAP_USAGE_ENABLE.disconnect();
         this._prefs.SWAP_USAGE_TEXT.disconnect();
     }
-}
-
-function init(meta) {
-    ExtensionUtils.initTranslations();
-    return new Extension(meta.uuid);
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -352,11 +352,7 @@ const Indicator = GObject.registerClass(
 
             const settingMenuItem = new PopupMenu.PopupMenuItem(_('Setting'));
             settingMenuItem.connect('activate', () => {
-                if (typeof this.extension.openPreferences === 'function') {
-                    this.extension.openPreferences();
-                } else {
-                    Util.spawn(['gnome-shell-extension-prefs', extension.uuid]);
-                }
+                this.extension.openPreferences();
             });
             this.menu.addMenuItem(settingMenuItem);
         }

--- a/src/extension.js
+++ b/src/extension.js
@@ -25,6 +25,7 @@ import GObject from 'gi://GObject';
 import St from 'gi://St';
 import Clutter from 'gi://Clutter';
 import Gio from 'gi://Gio';
+import Shell from 'gi://Shell';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,8 +2,8 @@
     "name": "Simple System Monitor",
     "description": "Show current CPU usage, memory usage and net speed on panel.",
     "uuid": "ssm-gnome@lgiki.net",
-    "version": 12,
-    "shell-version": ["44", "43", "42", "41", "40", "3.38", "3.36", "3.34"],
+    "version": 16,
+    "shell-version": ["45"],
     "gettext-domain": "gnome-shell-extension-simple-system-monitor",
     "url": "https://github.com/LGiki/gnome-shell-extension-simple-system-monitor"
 }

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -1,10 +1,11 @@
 import GObject from 'gi://GObject';
 import Gtk from 'gi://Gtk';
 import Gdk from 'gi://Gdk';
+import Adw from 'gi://Adw';
+
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 import * as Settings from './settings.js';
-
-const Configuration = new Settings.Prefs();
 
 const DEFAULT_SETTINGS = {
     extensionPosition: 'right',
@@ -65,190 +66,213 @@ const extensionPositionLabelToIndex = (selectedString) => {
     }
 };
 
-const SimpleSystemMonitorPrefsWidget = GObject.registerClass(
-    {
-        GTypeName: 'SimpleSystemMonitorPrefsWidget',
-        Template: Me.dir.get_child(WIDGET_TEMPLATE_FILE).get_uri(),
-        InternalChildren: [
-            'extension_position_combo_box',
-            'extension_order',
-            'font_weight',
-            'show_extra_spaces_switch',
-            'show_percent_sign_switch',
-            'cpu_usage_enable_switch',
-            'cpu_usage_text',
-            'memory_usage_enable_switch',
-            'memory_usage_text',
-            'download_speed_enable_switch',
-            'download_speed_text',
-            'upload_speed_enable_switch',
-            'upload_speed_text',
-            'item_separator',
-            'refresh_interval',
-            'font_button',
-            'text_color',
-            'swap_usage_enable_switch',
-            'swap_usage_text',
-        ],
-    },
-    class SimpleSystemMonitorPrefsWidget extends Gtk.Box {
-        _init() {
-            super._init({
-                orientation: Gtk.Orientation.VERTICAL,
-                spacing: 30,
-            });
+let SimpleSystemMonitorPrefsWidget = undefined
+let Configuration = undefined
+export default class SSMPreferences extends ExtensionPreferences {
+    
+    fillPreferencesWindow(window) {
+        this._configuration = new Settings.Prefs(this.getSettings(Settings.SETTING_SCHEMA))
+        window._settings = this.getSettings(Settings.SETTING_SCHEMA);
 
-            this.update_widget_setting_values();
+        if (Configuration === undefined) {
+            Configuration = this._configuration
+        }
+        if (SimpleSystemMonitorPrefsWidget === undefined) {
+            initWidget(this.dir)
         }
 
-        update_widget_setting_values() {
-            this._extension_position_combo_box.set_active(
-                extensionPositionLabelToIndex(Configuration.EXTENSION_POSITION.get()),
-            );
-            this._extension_order.set_value(Configuration.EXTENSION_ORDER.get());
-            this._font_weight.set_value(Configuration.FONT_WEIGHT.get());
-            this._show_extra_spaces_switch.set_active(Configuration.SHOW_EXTRA_SPACES.get());
-            this._show_percent_sign_switch.set_active(Configuration.SHOW_PERCENT_SIGN.get());
-            this._cpu_usage_enable_switch.set_active(Configuration.IS_CPU_USAGE_ENABLE.get());
-            this._cpu_usage_text.set_text(Configuration.CPU_USAGE_TEXT.get());
-            this._memory_usage_enable_switch.set_active(Configuration.IS_MEMORY_USAGE_ENABLE.get());
-            this._memory_usage_text.set_text(Configuration.MEMORY_USAGE_TEXT.get());
-            this._download_speed_enable_switch.set_active(
-                Configuration.IS_DOWNLOAD_SPEED_ENABLE.get(),
-            );
-            this._download_speed_text.set_text(Configuration.DOWNLOAD_SPEED_TEXT.get());
-            this._upload_speed_enable_switch.set_active(Configuration.IS_UPLOAD_SPEED_ENABLE.get());
-            this._upload_speed_text.set_text(Configuration.UPLOAD_SPEED_TEXT.get());
-            this._item_separator.set_text(Configuration.ITEM_SEPARATOR.get());
-            this._refresh_interval.set_value(Configuration.REFRESH_INTERVAL.get());
-            this._font_button.set_font(
-                `${Configuration.FONT_FAMILY.get()} ${Configuration.FONT_SIZE.get()}`,
-            );
-            this._swap_usage_enable_switch.set_active(Configuration.IS_SWAP_USAGE_ENABLE.get());
-            this._swap_usage_text.set_text(Configuration.SWAP_USAGE_TEXT.get());
-            const color = new Gdk.RGBA();
-            color.parse(Configuration.TEXT_COLOR.get());
-            this._text_color.set_rgba(color);
-        }
+        const page = new Adw.PreferencesPage();
 
-        reset_settings_to_default() {
-            Configuration.EXTENSION_POSITION.set(DEFAULT_SETTINGS.extensionPosition);
-            Configuration.EXTENSION_ORDER.set(DEFAULT_SETTINGS.extensionOrder);
-            Configuration.FONT_WEIGHT.set(DEFAULT_SETTINGS.fontWeight);
-            Configuration.SHOW_EXTRA_SPACES.set(DEFAULT_SETTINGS.showExtraSpaces);
-            Configuration.SHOW_PERCENT_SIGN.set(DEFAULT_SETTINGS.showPercentSign);
-            Configuration.IS_CPU_USAGE_ENABLE.set(DEFAULT_SETTINGS.isCpuUsageEnable);
-            Configuration.CPU_USAGE_TEXT.set(DEFAULT_SETTINGS.cpuUsageText);
-            Configuration.IS_MEMORY_USAGE_ENABLE.set(DEFAULT_SETTINGS.isMemoryUsageEnable);
-            Configuration.MEMORY_USAGE_TEXT.set(DEFAULT_SETTINGS.memoryUsageText);
-            Configuration.IS_DOWNLOAD_SPEED_ENABLE.set(DEFAULT_SETTINGS.isDownloadSpeedEnable);
-            Configuration.DOWNLOAD_SPEED_TEXT.set(DEFAULT_SETTINGS.downloadSpeedText);
-            Configuration.IS_UPLOAD_SPEED_ENABLE.set(DEFAULT_SETTINGS.isUploadSpeedEnable);
-            Configuration.UPLOAD_SPEED_TEXT.set(DEFAULT_SETTINGS.uploadSpeedText);
-            Configuration.ITEM_SEPARATOR.set(DEFAULT_SETTINGS.itemSeparator);
-            Configuration.REFRESH_INTERVAL.set(DEFAULT_SETTINGS.refreshInterval);
-            Configuration.FONT_FAMILY.set(DEFAULT_SETTINGS.fontFamily);
-            Configuration.FONT_SIZE.set(DEFAULT_SETTINGS.fontSize);
-            Configuration.TEXT_COLOR.set(DEFAULT_SETTINGS.textColor);
-            Configuration.IS_SWAP_USAGE_ENABLE.set(DEFAULT_SETTINGS.isSwapUsageEnable);
-            Configuration.SWAP_USAGE_TEXT.set(DEFAULT_SETTINGS.swapUsageText);
-        }
 
-        color_changed(widget) {
-            Configuration.TEXT_COLOR.set(colorToHex(widget.get_rgba()));
-        }
+        // CPU
+        const cpuGroup = new Adw.PreferencesGroup({
+            title: _('CPU Usage'),
+        });
+        
+        page.add(cpuGroup);
 
-        font_changed(widget) {
-            const font = widget.get_font();
-            const lastSpaceIndex = font.lastIndexOf(' ');
-            const fontFamily = font.substring(0, lastSpaceIndex);
-            const fontSize = font.substring(lastSpaceIndex, font.length);
-            Configuration.FONT_FAMILY.set(fontFamily);
-            Configuration.FONT_SIZE.set(fontSize);
-        }
-
-        extension_position_combo_box_changed(widget) {
-            const selectedIndex = widget.get_active();
-            const selectedString = extensionPositionIndexToLabel(selectedIndex);
-            Configuration.EXTENSION_POSITION.set(selectedString);
-        }
-
-        extension_order_changed(widget) {
-            Configuration.EXTENSION_ORDER.set(widget.get_value());
-        }
-
-        font_weight_changed(widget) {
-            Configuration.FONT_WEIGHT.set(widget.get_value());
-        }
-
-        show_extra_spaces_switch_changed(widget) {
-            Configuration.SHOW_EXTRA_SPACES.set(widget.get_active());
-        }
-
-        show_percent_sign_switch_changed(widget) {
-            Configuration.SHOW_PERCENT_SIGN.set(widget.get_active());
-        }
-
-        cpu_usage_enable_switch_changed(widget) {
-            Configuration.IS_CPU_USAGE_ENABLE.set(widget.get_active());
-        }
-
-        memory_usage_enable_switch_changed(widget) {
-            Configuration.IS_MEMORY_USAGE_ENABLE.set(widget.get_active());
-        }
-
-        download_speed_enable_switch_changed(widget) {
-            Configuration.IS_DOWNLOAD_SPEED_ENABLE.set(widget.get_active());
-        }
-
-        upload_speed_enable_switch_changed(widget) {
-            Configuration.IS_UPLOAD_SPEED_ENABLE.set(widget.get_active());
-        }
-
-        swap_usage_enable_switch_changed(widget) {
-            Configuration.IS_SWAP_USAGE_ENABLE.set(widget.get_active());
-        }
-
-        cpu_usage_text_changed(widget) {
-            Configuration.CPU_USAGE_TEXT.set(widget.get_text());
-        }
-
-        memory_usage_text_changed(widget) {
-            Configuration.MEMORY_USAGE_TEXT.set(widget.get_text());
-        }
-
-        swap_usage_text_changed(widget) {
-            Configuration.SWAP_USAGE_TEXT.set(widget.get_text());
-        }
-
-        download_usage_text_changed(widget) {
-            Configuration.DOWNLOAD_SPEED_TEXT.set(widget.get_text());
-        }
-
-        upload_usage_text_changed(widget) {
-            Configuration.UPLOAD_SPEED_TEXT.set(widget.get_text());
-        }
-
-        item_separator_changed(widget) {
-            Configuration.ITEM_SEPARATOR.set(widget.get_text());
-        }
-
-        refresh_interval_changed(widget) {
-            Configuration.REFRESH_INTERVAL.set(widget.get_value());
-        }
-
-        reset_settings_to_default_clicked(widget) {
-            this.reset_settings_to_default();
-            this.update_widget_setting_values();
-        }
-    },
-);
-
-function buildPrefsWidget() {
-    const widget = new SimpleSystemMonitorPrefsWidget();
-    widget.homogeneous = true;
-    if (Gtk.get_major_version() === 3) {
-        widget.show_all();
+        window.add(new SimpleSystemMonitorPrefsWidget(this._configuration));
     }
-    return widget;
+}
+
+
+function initWidget(dir) {
+    SimpleSystemMonitorPrefsWidget = GObject.registerClass(
+        {
+            GTypeName: 'SimpleSystemMonitorPrefsWidget',
+            Template: dir.get_child(WIDGET_TEMPLATE_FILE).get_uri(),
+            InternalChildren: [
+                'extension_position_combo_box',
+                'extension_order',
+                'font_weight',
+                'show_extra_spaces_switch',
+                'show_percent_sign_switch',
+                'cpu_usage_enable_switch',
+                'cpu_usage_text',
+                'memory_usage_enable_switch',
+                'memory_usage_text',
+                'download_speed_enable_switch',
+                'download_speed_text',
+                'upload_speed_enable_switch',
+                'upload_speed_text',
+                'item_separator',
+                'refresh_interval',
+                'font_button',
+                'text_color',
+                'swap_usage_enable_switch',
+                'swap_usage_text',
+            ],
+        },
+        class SimpleSystemMonitorPrefsWidget extends Adw.PreferencesPage {
+            _init() {
+                super._init({
+                    //orientation: Gtk.Orientation.VERTICAL,
+                    //spacing: 30,
+                });
+    
+                this.update_widget_setting_values();
+            }
+    
+            update_widget_setting_values() {
+                this._extension_position_combo_box.set_active(
+                    extensionPositionLabelToIndex(Configuration.EXTENSION_POSITION.get()),
+                );
+                this._extension_order.set_value(Configuration.EXTENSION_ORDER.get());
+                this._font_weight.set_value(Configuration.FONT_WEIGHT.get());
+                this._show_extra_spaces_switch.set_active(Configuration.SHOW_EXTRA_SPACES.get());
+                this._show_percent_sign_switch.set_active(Configuration.SHOW_PERCENT_SIGN.get());
+                this._cpu_usage_enable_switch.set_active(Configuration.IS_CPU_USAGE_ENABLE.get());
+                this._cpu_usage_text.set_text(Configuration.CPU_USAGE_TEXT.get());
+                this._memory_usage_enable_switch.set_active(Configuration.IS_MEMORY_USAGE_ENABLE.get());
+                this._memory_usage_text.set_text(Configuration.MEMORY_USAGE_TEXT.get());
+                this._download_speed_enable_switch.set_active(
+                    Configuration.IS_DOWNLOAD_SPEED_ENABLE.get(),
+                );
+                this._download_speed_text.set_text(Configuration.DOWNLOAD_SPEED_TEXT.get());
+                this._upload_speed_enable_switch.set_active(Configuration.IS_UPLOAD_SPEED_ENABLE.get());
+                this._upload_speed_text.set_text(Configuration.UPLOAD_SPEED_TEXT.get());
+                this._item_separator.set_text(Configuration.ITEM_SEPARATOR.get());
+                this._refresh_interval.set_value(Configuration.REFRESH_INTERVAL.get());
+                this._font_button.set_font(
+                    `${Configuration.FONT_FAMILY.get()} ${Configuration.FONT_SIZE.get()}`,
+                );
+                this._swap_usage_enable_switch.set_active(Configuration.IS_SWAP_USAGE_ENABLE.get());
+                this._swap_usage_text.set_text(Configuration.SWAP_USAGE_TEXT.get());
+                const color = new Gdk.RGBA();
+                color.parse(Configuration.TEXT_COLOR.get());
+                this._text_color.set_rgba(color);
+            }
+    
+            reset_settings_to_default() {
+                Configuration.EXTENSION_POSITION.set(DEFAULT_SETTINGS.extensionPosition);
+                Configuration.EXTENSION_ORDER.set(DEFAULT_SETTINGS.extensionOrder);
+                Configuration.FONT_WEIGHT.set(DEFAULT_SETTINGS.fontWeight);
+                Configuration.SHOW_EXTRA_SPACES.set(DEFAULT_SETTINGS.showExtraSpaces);
+                Configuration.SHOW_PERCENT_SIGN.set(DEFAULT_SETTINGS.showPercentSign);
+                Configuration.IS_CPU_USAGE_ENABLE.set(DEFAULT_SETTINGS.isCpuUsageEnable);
+                Configuration.CPU_USAGE_TEXT.set(DEFAULT_SETTINGS.cpuUsageText);
+                Configuration.IS_MEMORY_USAGE_ENABLE.set(DEFAULT_SETTINGS.isMemoryUsageEnable);
+                Configuration.MEMORY_USAGE_TEXT.set(DEFAULT_SETTINGS.memoryUsageText);
+                Configuration.IS_DOWNLOAD_SPEED_ENABLE.set(DEFAULT_SETTINGS.isDownloadSpeedEnable);
+                Configuration.DOWNLOAD_SPEED_TEXT.set(DEFAULT_SETTINGS.downloadSpeedText);
+                Configuration.IS_UPLOAD_SPEED_ENABLE.set(DEFAULT_SETTINGS.isUploadSpeedEnable);
+                Configuration.UPLOAD_SPEED_TEXT.set(DEFAULT_SETTINGS.uploadSpeedText);
+                Configuration.ITEM_SEPARATOR.set(DEFAULT_SETTINGS.itemSeparator);
+                Configuration.REFRESH_INTERVAL.set(DEFAULT_SETTINGS.refreshInterval);
+                Configuration.FONT_FAMILY.set(DEFAULT_SETTINGS.fontFamily);
+                Configuration.FONT_SIZE.set(DEFAULT_SETTINGS.fontSize);
+                Configuration.TEXT_COLOR.set(DEFAULT_SETTINGS.textColor);
+                Configuration.IS_SWAP_USAGE_ENABLE.set(DEFAULT_SETTINGS.isSwapUsageEnable);
+                Configuration.SWAP_USAGE_TEXT.set(DEFAULT_SETTINGS.swapUsageText);
+            }
+    
+            color_changed(widget) {
+                Configuration.TEXT_COLOR.set(colorToHex(widget.get_rgba()));
+            }
+    
+            font_changed(widget) {
+                const font = widget.get_font();
+                const lastSpaceIndex = font.lastIndexOf(' ');
+                const fontFamily = font.substring(0, lastSpaceIndex);
+                const fontSize = font.substring(lastSpaceIndex, font.length);
+                Configuration.FONT_FAMILY.set(fontFamily);
+                Configuration.FONT_SIZE.set(fontSize);
+            }
+    
+            extension_position_combo_box_changed(widget) {
+                const selectedIndex = widget.get_active();
+                const selectedString = extensionPositionIndexToLabel(selectedIndex);
+                Configuration.EXTENSION_POSITION.set(selectedString);
+            }
+    
+            extension_order_changed(widget) {
+                Configuration.EXTENSION_ORDER.set(widget.get_value());
+            }
+    
+            font_weight_changed(widget) {
+                Configuration.FONT_WEIGHT.set(widget.get_value());
+            }
+    
+            show_extra_spaces_switch_changed(widget) {
+                Configuration.SHOW_EXTRA_SPACES.set(widget.get_active());
+            }
+    
+            show_percent_sign_switch_changed(widget) {
+                Configuration.SHOW_PERCENT_SIGN.set(widget.get_active());
+            }
+    
+            cpu_usage_enable_switch_changed(widget) {
+                Configuration.IS_CPU_USAGE_ENABLE.set(widget.get_active());
+            }
+    
+            memory_usage_enable_switch_changed(widget) {
+                Configuration.IS_MEMORY_USAGE_ENABLE.set(widget.get_active());
+            }
+    
+            download_speed_enable_switch_changed(widget) {
+                Configuration.IS_DOWNLOAD_SPEED_ENABLE.set(widget.get_active());
+            }
+    
+            upload_speed_enable_switch_changed(widget) {
+                Configuration.IS_UPLOAD_SPEED_ENABLE.set(widget.get_active());
+            }
+    
+            swap_usage_enable_switch_changed(widget) {
+                Configuration.IS_SWAP_USAGE_ENABLE.set(widget.get_active());
+            }
+    
+            cpu_usage_text_changed(widget) {
+                Configuration.CPU_USAGE_TEXT.set(widget.get_text());
+            }
+    
+            memory_usage_text_changed(widget) {
+                Configuration.MEMORY_USAGE_TEXT.set(widget.get_text());
+            }
+    
+            swap_usage_text_changed(widget) {
+                Configuration.SWAP_USAGE_TEXT.set(widget.get_text());
+            }
+    
+            download_usage_text_changed(widget) {
+                Configuration.DOWNLOAD_SPEED_TEXT.set(widget.get_text());
+            }
+    
+            upload_usage_text_changed(widget) {
+                Configuration.UPLOAD_SPEED_TEXT.set(widget.get_text());
+            }
+    
+            item_separator_changed(widget) {
+                Configuration.ITEM_SEPARATOR.set(widget.get_text());
+            }
+    
+            refresh_interval_changed(widget) {
+                Configuration.REFRESH_INTERVAL.set(widget.get_value());
+            }
+    
+            reset_settings_to_default_clicked(widget) {
+                this.reset_settings_to_default();
+                this.update_widget_setting_values();
+            }
+        },
+    );
 }

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -1,8 +1,9 @@
-const { GObject, Gtk, Gdk } = imports.gi;
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk';
+import Gdk from 'gi://Gdk';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Settings = Me.imports.settings;
+import * as Settings from './settings.js';
+
 const Configuration = new Settings.Prefs();
 
 const DEFAULT_SETTINGS = {
@@ -242,10 +243,6 @@ const SimpleSystemMonitorPrefsWidget = GObject.registerClass(
         }
     },
 );
-
-function init() {
-    ExtensionUtils.initTranslations();
-}
 
 function buildPrefsWidget() {
     const widget = new SimpleSystemMonitorPrefsWidget();

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -81,16 +81,6 @@ export default class SSMPreferences extends ExtensionPreferences {
             initWidget(this.dir)
         }
 
-        const page = new Adw.PreferencesPage();
-
-
-        // CPU
-        const cpuGroup = new Adw.PreferencesGroup({
-            title: _('CPU Usage'),
-        });
-        
-        page.add(cpuGroup);
-
         window.add(new SimpleSystemMonitorPrefsWidget(this._configuration));
     }
 }

--- a/src/prefs.ui
+++ b/src/prefs.ui
@@ -35,6 +35,10 @@
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can-focus">True</property>
+        <property name="margin-start">30</property>
+        <property name="margin-end">30</property>
+        <property name="margin-top">30</property>
+        <property name="margin-bottom">30</property>
         <property name="orientation">vertical</property>
 
         <child>

--- a/src/prefs.ui
+++ b/src/prefs.ui
@@ -28,9 +28,10 @@
       <row><col id="0">Right</col></row>
     </data>
   </object>
-  <template class="SimpleSystemMonitorPrefsWidget" parent="GtkBox">
+  <template class="SimpleSystemMonitorPrefsWidget" parent="AdwPreferencesPage">
     <child>
-
+    <object class="GtkScrolledWindow">
+    <child>
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can-focus">True</property>
@@ -1370,6 +1371,8 @@ Positive Values: starting from the left side</property>
         </child>
 
       </object>
+    </child>
+    </object>
     </child>
   </template>
 </interface>

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,10 +1,11 @@
-const ExtensionUtils = imports.misc.extensionUtils;
+import { Extension, gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 const SETTING_SCHEMA = 'org.gnome.shell.extensions.simple-system-monitor';
 
-var Prefs = class Prefs {
+export var Prefs = class Prefs {
     constructor() {
-        const settings = ExtensionUtils.getSettings(SETTING_SCHEMA);
+        const extension = Extension.lookupByUUID('ssm-gnome@lgiki.net');
+        const settings = extension.getSettings(SETTING_SCHEMA);
 
         this.EXTENSION_POSITION = new PrefValue(settings, 'extension-position', 'string');
         this.EXTENSION_ORDER = new PrefValue(settings, 'extension-order', 'int');
@@ -33,7 +34,7 @@ var Prefs = class Prefs {
     }
 };
 
-class PrefValue {
+export class PrefValue {
     constructor(gioSettings, key, type) {
         this._gioSettings = gioSettings;
         this._key = key;

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,12 +1,13 @@
-import { Extension, gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 
-const SETTING_SCHEMA = 'org.gnome.shell.extensions.simple-system-monitor';
+//import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+export const SETTING_SCHEMA = 'org.gnome.shell.extensions.simple-system-monitor';
+
 
 export var Prefs = class Prefs {
-    constructor() {
-        const extension = Extension.lookupByUUID('ssm-gnome@lgiki.net');
-        const settings = extension.getSettings(SETTING_SCHEMA);
+    
 
+    constructor(settings) {
         this.EXTENSION_POSITION = new PrefValue(settings, 'extension-position', 'string');
         this.EXTENSION_ORDER = new PrefValue(settings, 'extension-order', 'int');
         this.FONT_WEIGHT = new PrefValue(settings, 'font-weight', 'int');


### PR DESCRIPTION
Hey there 👋
Due to GNOME being such great developers, making it that GNOME 45 breaks everything, I made it so that the extension is runnable with it.

Of course, there are some drawbacks and issues:

1. As stated [here](https://gjs.guide/extensions/upgrading/gnome-shell-45.html#shell-version), this version is not backwards compatible. I myself would create a seperate branch, or move the current master branch somewhere else, as a preservation. 
2. This version is only barebones: the config-menu has been [overhauled](https://gjs.guide/extensions/upgrading/gnome-shell-45.html#prefs-js), causing the current version to break, and another issue with opening the System Monitor. 
I am not willing to work on these currently, because there is an issue with [restarting it on X11](https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/7050), only circumventable by closing every window.