### PR TITLE
feat: Support for GNOME 46

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,8 +2,8 @@
     "name": "Simple System Monitor",
     "description": "Show current CPU usage, memory usage and net speed on panel.",
     "uuid": "ssm-gnome@lgiki.net",
-    "version": 15,
-    "shell-version": ["45"],
+    "version": 16,
+    "shell-version": ["45", "46"],
     "gettext-domain": "gnome-shell-extension-simple-system-monitor",
     "url": "https://github.com/LGiki/gnome-shell-extension-simple-system-monitor"
 }


### PR DESCRIPTION
Hello 👋

The extension is compatible with gnome 46.
I have just updated the shell and extension version.